### PR TITLE
add issue templates and CoC

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,39 @@
+name: Bug Report
+description: File a bug report.
+title: "[Bug]: "
+labels: ["bug"]
+type: Bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this issue! By 
+        submitting this issue, you agree to follow our [Code of Conduct](https://github.com/nmfs-ost/on-off-boarding?tab=coc-ov-file),
+        which uses the NOAA Fisheries Integrated Toolbox Code of Conduct.
+        
+        ---
+
+        Before filling out this report please search the existing issues to see
+        if the problem has already been reported. If it has, please add a
+        comment to the open issue or link to the related, but closed, issue in
+        this report.
+  
+  - type: textarea
+    id: describe
+    attributes:
+      label: Describe the bug
+      description: Please provide a description of the bug. Also tell us, what did you expect to happen?
+    validations:
+      required: true
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: Describe how to reproduce the bug
+      description: "How can we reproduce the bug? Please be as specific as possible."
+      value: |
+        1. 
+        2. 
+        3. 
+        ...
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/developer_other_issue.yml
+++ b/.github/ISSUE_TEMPLATE/developer_other_issue.yml
@@ -1,0 +1,28 @@
+name: Developer (other issue)
+description: |
+  This issue form is for developers of nmfs-ost/on-off-boarding to
+  document anything that is not related to a bug or feature.
+title: "[Developers]: "
+type: Task
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this issue! By 
+        submitting this issue, you agree to follow our [Code of Conduct](https://github.com/nmfs-ost/on-off-boarding?tab=coc-ov-file),
+        which uses the NOAA Fisheries Integrated Toolbox Code of Conduct.
+
+        ---
+
+        Before filling out this report please search the existing issues to see
+        if the problem has already been reported. If it has, please add a
+        comment to the open issue or link to the related, but closed, issue in
+        this report.
+  - type: textarea
+    id: describe
+    attributes:
+      label: Description
+      description: Please describe the problem.
+    validations:
+      required: true
+      

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,47 @@
+name: Feature Request
+description: Request new features or changes to features
+title: "[Feature]: "
+labels: ["enhancement"]
+type: Feature
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this issue! By 
+        submitting this issue, you agree to follow our [Code of Conduct](https://github.com/nmfs-ost/on-off-boarding?tab=coc-ov-file),
+        which uses the NOAA Fisheries Integrated Toolbox Code of Conduct.
+        
+        ---
+
+        Before filling out this report please search the existing issues to see
+        if the feature has already been reported. If it has, please add a
+        comment to the open issue or link to the related, but closed, issue in
+        this report.
+  - type: textarea
+    id: description
+    attributes:
+      label: Describe the situation that led to the request and a solution
+      description: |
+        Provide (1) a description of your new feature or change to a current feature, (2) the problem that led to you thinking that the enhancement
+        is a good idea, and (3) a proposed solution.
+      placeholder: |
+        I would like <x> because I am frustrated when <y> happens and this
+        could be fixed by <z>.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternative solutions
+      description: |
+        Please provide descriptions of any alternative solutions to fulfilling
+        this enhancement request that you have considered.
+    validations:
+      required: false
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Add any other context or screenshots about the feature request here.
+    validations:
+      required: false

--- a/.github/workflows/sync-code-of-conduct.yml
+++ b/.github/workflows/sync-code-of-conduct.yml
@@ -1,0 +1,48 @@
+name: Sync Code of Conduct
+
+on:
+  # Allows to run this workflow manually from the Actions tab
+  workflow_dispatch:
+  # Runs at 00:00 UTC on the 1st day of every month
+  schedule:
+    - cron: '0 0 1 * *'
+
+# Grant the GITHUB_TOKEN write permissions to push the changes
+permissions:
+  contents: write
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      # Check out repository's code
+      - name: Checkout Repo
+        uses: actions/checkout@v4
+
+      # Download the CoC file from the source repository
+      - name: Download CoC from Source Repo
+        run: |
+          curl -o CODE_OF_CONDUCT.md https://raw.githubusercontent.com/nmfs-ost/FIT-resource-files/refs/heads/main/CODE_OF_CONDUCT.md
+
+      # Modify the downloaded file with custom details
+      - name: Modify Enforcement Section
+        run: |
+          sed -i 's|enforcement at.*|enforcement at [Contact information to be determined].|' CODE_OF_CONDUCT.md
+      
+      # Check for changes, and if there are any, commit and push them
+      - name: Commit and Push if Changed
+        run: |
+          # Configure Git with a bot user
+          git config --global user.name 'github-actions[bot]'
+          git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+          
+          # Add the downloaded file to the staging area
+          git add CODE_OF_CONDUCT.md
+          
+          # Commit and push only if there are changes
+          if ! git diff --staged --quiet; then
+            git commit -m "chore: Sync Code of Conduct from source repo"
+            git push
+          else
+            echo "No changes to the Code of Conduct. No commit needed."
+          fi


### PR DESCRIPTION
* Add bug_report, developer_other_issue, and feature_request issue templates.
* Add a workflow to sync the Code of Conduct from the NOAA Fisheries Integrated Toolbox repository.