### PR TITLE
Offboard NSAP and workflows command

### DIFF
--- a/.github/workflows/offboard-nsap.yml
+++ b/.github/workflows/offboard-nsap.yml
@@ -19,13 +19,12 @@ jobs:
             Farewell :v: : wishing you goodluck in your endeavors outside of our organization!
             Below you will find a list of offboarding tasks for both you and for the Project Lead.
             Please mark off tasks once they are accomplished to ease the communication chain and decrease duplication. 
-            Feel free reach out on the [asar Discussion Board]( https://github.com/nmfs-ost/asar/discussions) if you
-            want to chat about anything.
+            Feel free reach out on the NSAP Google Chat if you want to discuss about anything.
 
             ## Offboardee
               - [ ] Schedule 1:1 meeting with project lead
               - [ ] Transfer ownership of any documents/files in Google Drive
-              - [ ] Back up all files/created assets made during work
+              - [ ] Organize and save relevant local files to your respective project folder in the NSAP shared drive
               - [ ] Contact Chris Bradley for directions on returning your laptop
               
             ## Relevant leads (please edit this comment and assign the following tasks to the revelant people)
@@ -34,5 +33,6 @@ jobs:
               - [ ] Remove from noaa-ost GitHub organization
               - [ ] Remove from the NSAP GitHub Team
               - [ ] Remove from project specific GitHub repository(ies)
+              - [ ] Transfer ownership of non-exploratory GitHub repositories to the nmfs-ost Organization
               - [ ] Remove offboardee from individual Google Meet invites (meet owners will receieve a kickback email once their account is deactivated)
               

--- a/.github/workflows/offboard-workflows.yml
+++ b/.github/workflows/offboard-workflows.yml
@@ -27,5 +27,4 @@ jobs:
             ## Project leads
               - [ ] Remove access to *project* level resources
               - [ ] Remove offboardee from individual Google Meet invites
-              - [ ] 
               


### PR DESCRIPTION
Create yml scripts for offboarding nsap and workflows. The commands were already located in the slash-command-dispatch.yml so they were not added. 

I have a couple discussion questions:

- Are the additional offboarding tasks anyone can think of for offboard-nsap?
- Do you like the top message for offboarding-nsap?
- Do we want to keep the message at the top of a project specific checklist short (assuming that the nsap one is always initiated first)?