### PR TITLE
Removes WSL install instructions

### DIFF
--- a/getting-started.qmd
+++ b/getting-started.qmd
@@ -126,6 +126,8 @@ Only projects that are associated with a GitHub repository are listed in the tab
 <img src="assets/stockplotr-hex.png" alt="stock plot R logo" width="55" height="55"/>
 </p>
 
+See the [Fisheries Information Toolbox (FIT) Blog](https://nmfs-ost.github.io/noaa-fit-resources/) for help on installing software and using various cloud resources.
+
 ### IDEs
 
 #### Positron
@@ -139,46 +141,3 @@ Download the latest version of RStudio from [Posit's](https://posit.co) [downloa
 #### Visual Studio Code
 
 [Visual Studio Code (VS Code)](https://code.visualstudio.com/) is an [Electron](https://electronjs.org/) app that is meant to facilitate coding in any language. To download the latest version navigate to their [download page](https://code.visualstudio.com/Download) and follow the instructions specific to your operating system.
-
-### WSL
-
-Windows Subsystem for Linux (WSL) allows developers to run a Linux on your personal machine without having to use a dual-boot setup. This install takes help from the IT department if you are working on a NOAA-issued computer.
-
-#### :hammer: Install WSL2 and Docker Engine
-
-- Install WSL2 and Docker Engine on the Windows machine with IT. Both tools are on the [approved software list](https://docs.google.com/spreadsheets/d/1oPaTegdBGEmkjrmkbOVjGAJpPFg755p3Wws50ddLwCI/edit?usp=sharing).
-- For installation details, see the official [WSL documentation](https://learn.microsoft.com/en-us/windows/wsl/install) and [Docker documentation](https://docs.docker.com/engine/install/).
-- Be sure to have IT "Turn Windows features on or off" for WSL on Windows in addition to installing it. Here are some [similar instructions](https://www.tenforums.com/tutorials/46769-enable-disable-windows-subsystem-linux-wsl-windows-10-a.html) to what IT will need to do.
-
-#### :hammer: Install VS Code and extensions
-
-Open VS Code and install the following extensions from the Extensions view
-(`Ctrl + Shift + X`):
-- WSL extension (ID: ms-vscode-remote.remote-wsl): allows VS Code to connect to the WSL2 environment.
-- Dev Containers extension (ID: ms-vscode-remote.remote-containers): builds and manages development containers from the `.devcontainers/devcontainer.json` file.
-
-#### :hammer: Install Ubuntu
-
-- Open a Windows Command Prompt and check if `Ubuntu` is listed as a WSL distribution:
-
-```bash
-wsl --list --verbose
-```
-
-If `Ubuntu` is not listed under the `NAME` column, run the following command
-to install it:
-Ubuntu: 
-```Bash
-wsl --install -d Ubuntu
-```
-
-## 💬 AI Resources at NOAA Fisheries
-
-![Google Gemini](https://img.shields.io/badge/google%20gemini-8E75B2?style=for-the-badge&logo=google%20gemini&logoColor=white) ![ChatGPT](https://img.shields.io/badge/chatGPT-74aa9c?style=for-the-badge&logo=openai&logoColor=white)
-
-::: {.callout-important}
-AI tools are currently under pilot use and only some users 
-have access to GitHub copilot.
-:::
-
-## ☁️ Cloud Resources at NOAA Fisheries


### PR DESCRIPTION
Also removes headers for cloud resources because the content below them were empty

Provides a link to FIT blog where WSL content will be moved to

Close #74 